### PR TITLE
made ticker to resolve speedup after idle

### DIFF
--- a/slingshotchess.js
+++ b/slingshotchess.js
@@ -214,20 +214,84 @@ function init() {
     });
 }
 
+/* simple ticker class */
+let Ticker = class {
+    constructor(intervalms) {
+        this.ticks = -1;
+        this.waiter = null;
+        this.ticker = -1;
+        this.interval = intervalms;
+    }
+
+    isRunning() {
+        return (this.ticker != -1);
+    }
+
+    start() {
+        if ( ! this.isRunning() ) {
+            this.ticker = window.setInterval(this.tick.bind(this),this.interval);
+        }
+        this.tick();
+    }
+
+    stop() {
+        if ( this.isRunning() ) {
+            pause();
+            reset();
+        }
+    }
+
+    pause() {
+        if ( this.isRunning() ) {
+            window.clearInterval(this.ticker);
+            this.ticker = -1;
+        }
+    }
+
+    reset() {
+        this.ticks = 0;
+    }
+
+    tick() {
+        this.ticks++;
+        this.lastTick = Date.now();
+        if ( this.waiter !== null ) {
+            this.waiter();
+            this.waiter = null;
+        }
+    }
+
+    async waitForNextTick(currentTick) {
+        let p = new Promise( resolve => {
+            if ( currentTick < this.ticks ) {
+                resolve();
+            } else {
+                this.waiter = resolve;
+            }
+        });
+        return p;
+    }
+}
+
 async function runMainLoop() {
     // Main game loop!
     // https://dewitters.com/dewitters-gameloop/
-    var nextTimestep = Date.now();
+
+    let ticker = new Ticker(MILLIS_BETWEEN_TIMESTEPS);
+    let gametick = 0;
+    ticker.start();
+
     while (true) {
+        await ticker.waitForNextTick(gametick);
+
         var loops = 0;
-        while (Date.now() > nextTimestep && loops < MAX_RENDER_SKIPS) {
+        while (ticker.ticks > gametick && loops < MAX_RENDER_SKIPS) {
             updateGameState();
-            nextTimestep += MILLIS_BETWEEN_TIMESTEPS;
-            loops += 1;
+            ++gametick;
+            ++loops;
         }
         render();
         window.requestAnimationFrame(time => {});
-        await sleep(Math.max(0, nextTimestep - Date.now()));
     }
 }
 


### PR DESCRIPTION
resolves https://github.com/Kevinpgalligan/slingshot-chess/issues/3

The problem here was that:
- the javascript idles while the tab is not active / device is locked etc;
- the game loop uses clock time to measure lag;
- the game state and render loops are hard locked such that only up to 5 game loops can be ran for each render loop.

As a result, when javascript resumes, the game loops starts running 5 game state updates and 1 render update in a loop as fast as possible until the game state has caught up with the wall clock.  All of this "catching up" is unnecessary since the user was, by definition, not interacting with the game while the javascript was idled by the browser.

I fixed this by making the game loop run on "ticks" instead which are generated by window.setInterval, and wrapped in a class that keeps up with the tick count.  setInterval also idles along with the rest of the game so there are simply no ticks to catch up with when the browser is resumed.  A Promise and tick count differential is still used to return control immediately to the loop if the render loop is behind, or otherwise wait for the next tick.  It's hard to tell but this may also slightly improve performance - at the very least we've saved a heap of calls to window.setTimeout.

