### PR TITLE
Added animation queue

### DIFF
--- a/slingshotchess.js
+++ b/slingshotchess.js
@@ -161,8 +161,9 @@ class AnimationManager {
         let i = this.queue.length;
         // iterate backwards to allow deletion
         while ( i-- ) {
+            this.ctx.save();
             this.queue[i].draw(this.ctx,tm);
-            this.ctx.resetTransform();
+            this.ctx.restore();
             if(this.queue[i].isFinished) {
                 this.queue.splice(i,1);
             }
@@ -202,6 +203,9 @@ class PieceDeathAnimation {
 
         // this scales over time
         const scale = 1 - (currTime / this.duration);
+
+        // :)
+        ctx.globalAlpha = scale; 
 
         ctx.translate(xPixels,yPixels);
         ctx.rotate(rotate);


### PR DESCRIPTION
Addresses https://github.com/Kevinpgalligan/slingshot-chess/issues/1

Added an animation queue and a sample animation for pieces that fall off the board.  It's a little silly as-is but demonstrates a few simple things that can be done.  Other animations can be created as long as they have a .isFinished parameter and a draw(ctx,tm) method.